### PR TITLE
update z3 submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "z3-sys/z3"]
 	path = z3-sys/z3
-	url = https://github.com/Z3Prover/z3.git
+	url = https://github.com/umutdural/z3.git


### PR DESCRIPTION
CMake version 4.0 requires that no versions older than 3.5 are supported. To resolve this issue, the Z3 submodule in this PR points to a different repository where the minimum required version has been updated.